### PR TITLE
Make js bindings more efficient

### DIFF
--- a/bindings/js/Cargo.toml
+++ b/bindings/js/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "mrklj"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andrew Dirksen <andrew@dirksen.com>"]
 edition = "2018"
 description = """
 Merkle root generation, merkle proof generation and verification.
 """
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/docknetwork/rify"
+repository = "https://github.com/docknetwork/mrklt"
 readme = "README.md"
 
 [package.metadata.wasm-pack.profile.release]

--- a/bindings/js/README.md
+++ b/bindings/js/README.md
@@ -1,3 +1,3 @@
 JS bindings for mrklt.
 
-These bindings support only one hash, Blake2s. The merge algorithm is hard-coded, leaves are hashed twice to prevent Second Preimage Attacks.
+These bindings support only one hash, Blake2b256. The merge algorithm is hard-coded, leaves are hashed twice to prevent Second Preimage Attacks.

--- a/bindings/js/package.json
+++ b/bindings/js/package.json
@@ -4,11 +4,11 @@
     "Andrew Dirksen <andrew@dirksen.com>"
   ],
   "description": "Merkle root generation, merkle proof generation and verification.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT OR Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/docknetwork/mrkl"
+    "url": "https://github.com/docknetwork/mrklt"
   },
   "files": [
     "index_bg.wasm",

--- a/bindings/js/testjs/package.json
+++ b/bindings/js/testjs/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "dependencies": {
-    "blake2s-js": "^1.3.0",
+    "blakejs": "^1.1.0",
     "chai": "^4.2.0",
     "deep-equal": "^2.0.4",
     "mrklj": "../pkg"

--- a/bindings/js/testjs/test.js
+++ b/bindings/js/testjs/test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { compute_root, create_proof, verify_proof, construct } from 'mrklj';
-import BLAKE2s from 'blake2s-js';
+import { blake2b } from 'blakejs';
 import assert from 'assert';
 import deepEqual from 'deep-equal';
 
@@ -38,7 +38,7 @@ tests([
       utf8("srsly"),
       utf8("Odd number of leaves means an unbalanced merkle tree but it should still work."),
     ];
-    const leaf_hashes = testleaves.map(blake2s);
+    const leaf_hashes = testleaves.map(blake2b256);
     const lh_packed = pack32(leaf_hashes);
     const root = compute_root(lh_packed);
     const proofs = leaf_hashes.map((_, i) => create_proof(i, lh_packed));
@@ -53,7 +53,7 @@ tests([
       utf8("3"),
       utf8("4"),
     ];
-    const leaf_hashes = testleaves.map(blake2s);
+    const leaf_hashes = testleaves.map(blake2b256);
     const lh_packed = pack32(leaf_hashes);
     const root = compute_root(lh_packed);
     const proofs = leaf_hashes.map((_, i) => create_proof(i, lh_packed));
@@ -69,46 +69,48 @@ tests([
       utf8("2"),
       utf8("3"),
     ];
-    const leaf_hashes = testleaves.map(blake2s);
+    const leaf_hashes = testleaves.map(blake2b256);
     const lh_packed = pack32(leaf_hashes);
     const root = compute_root(lh_packed);
     const proofs = leaf_hashes.map((_, i) => create_proof(i, lh_packed));
     expect(root).to.deep.equal(new Uint8Array([
-      129, 200, 233, 73, 31, 39, 141, 117, 148, 124, 248, 116, 3, 216, 180, 82,
-      228, 244, 145, 31, 56, 205, 241, 85, 174, 94, 170, 12, 19, 228, 198, 164
+      139, 45, 145, 103, 46, 124, 238, 23, 51, 84, 193, 22, 201, 120, 11, 88, 127, 192, 49, 28, 165,
+      31, 74, 143, 112, 84, 7, 204, 228, 5, 214, 236
     ]));
     expect(proofs).to.deep.equal([
       [
         {
           Right: [
-            225, 249, 175, 63, 145, 98, 79, 188, 171, 95, 57, 196, 203, 174, 70, 222,
-            183, 145, 208, 72, 39, 24, 74, 24, 80, 10, 37, 96, 240, 40, 239, 65
+            151, 61, 106, 145, 33, 102, 201, 84, 145, 96, 87, 235, 106, 7, 211, 232, 191, 69, 31,
+            204, 170, 186, 139, 247, 255, 246, 44, 174, 42, 19, 199, 64
           ]
-        }, {
+        },
+        {
           Right: [
-            95, 190, 36, 79, 242, 19, 244, 31, 231, 117, 175, 188, 226, 50, 8, 114,
-            157, 188, 100, 236, 215, 125, 176, 182, 114, 7, 145, 240, 156, 182, 75, 56
+            100, 0, 145, 252, 75, 92, 47, 44, 17, 241, 128, 30, 80, 82, 6, 53, 157, 139, 2, 153,
+            84, 121, 13, 220, 10, 183, 200, 148, 56, 181, 136, 118
           ]
         }
       ],
       [
         {
           Left: [
-            119, 194, 250, 6, 9, 173, 18, 24, 21, 138, 21, 10, 21, 85, 204, 7,
-            157, 145, 77, 37, 210, 161, 133, 12, 155, 14, 102, 64, 104, 17, 196, 197
+            206, 225, 179, 65, 151, 130, 173, 146, 236, 45, 255, 237, 109, 63, 54, 203, 153, 244,
+            190, 143, 114, 128, 255, 227, 168, 116, 176, 43, 255, 169, 168, 97
           ]
-        }, {
+        },
+        {
           Right: [
-            95, 190, 36, 79, 242, 19, 244, 31, 231, 117, 175, 188, 226, 50, 8, 114,
-            157, 188, 100, 236, 215, 125, 176, 182, 114, 7, 145, 240, 156, 182, 75, 56
+            100, 0, 145, 252, 75, 92, 47, 44, 17, 241, 128, 30, 80, 82, 6, 53, 157, 139, 2, 153, 84,
+            121, 13, 220, 10, 183, 200, 148, 56, 181, 136, 118
           ]
         }
       ],
       [
         {
           Left: [
-            38, 175, 220, 15, 117, 10, 163, 114, 151, 247, 152, 47, 235, 153, 30, 18,
-            17, 185, 255, 198, 26, 98, 234, 166, 105, 186, 89, 25, 112, 127, 165, 85
+            19, 242, 94, 150, 193, 248, 24, 234, 126, 25, 62, 124, 156, 160, 118, 185, 207, 204,
+            201, 5, 4, 114, 42, 54, 124, 47, 119, 252, 4, 33, 162, 189
           ]
         }
       ]
@@ -138,11 +140,10 @@ function utf8(str) {
   return new TextEncoder("utf-8").encode(str);
 }
 
-// hash a byte array using blake2s-256
-function blake2s(bs) {
-  let h = new BLAKE2s();
-  h.update(bs);
-  return h.digest();
+// hash a byte array using blake2b-256
+function blake2b256(bs) {
+  assert(bs instanceof Uint8Array);
+  return blake2b(bs, undefined, 32);
 }
 
 // pack a list of hashed leaves into a single byte array

--- a/bindings/js/testjs/test.js
+++ b/bindings/js/testjs/test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { compute_root, create_proof, verify_proof } from 'mrklj';
+import { compute_root, create_proof, verify_proof, construct } from 'mrklj';
 import BLAKE2s from 'blake2s-js';
 import assert from 'assert';
 import deepEqual from 'deep-equal';
@@ -114,7 +114,25 @@ tests([
       ]
     ]);
   }],
+  ['construct() has the same result as compute_root() together with create_proof()', () => {
+    for (let i = 1; i < 30; i++) {
+      const leaf_hashes = randoLeaves(i);
+      const lh_packed = pack32(leaf_hashes);
+      const root = compute_root(lh_packed);
+      const proofs = leaf_hashes.map((_, i) => create_proof(i, lh_packed));
+      const [otherRoot, otherProofs] = construct(lh_packed);
+      expect([[...root], proofs]).to.deep.eq([otherRoot, otherProofs]);
+    }
+  }],
 ]);
+
+function randoLeaves(count) {
+  return Array(count).fill(undefined).map(() => randoHash());
+}
+
+function randoHash() {
+  return new Uint8Array(Array(32).fill(undefined).map(() => Math.floor(Math.random() * 256)));
+}
 
 function utf8(str) {
   return new TextEncoder("utf-8").encode(str);


### PR DESCRIPTION
This pr introduces two optimizations:
1. Make it possible to compute all proofs and merkle root at the same time. This reduces the number of required hashes. closes #3
2. Switch from blake2s-256 to blake2b-256. this is a breaking change
